### PR TITLE
Update docker_entrypoint.sh

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -8,7 +8,8 @@ fi
 
 echo "设定远程仓库地址..."
 cd /scripts
-git remote set-url origin $REPO_URL
+git remote set-url origin https://gitee.com/lxk0301/jd_scripts
+echo "--------------固定地址-防止群晖直接DOCKER容器直接挂掉---"
 git reset --hard
 echo "git pull拉取最新代码..."
 git -C /scripts pull


### PR DESCRIPTION
群晖docker无法获取$REPO_URL的值,固定地址-防止群晖直接DOCKER容器直接挂掉