### PR TITLE
增加云函数地区配置变量SCF_REGION

### DIFF
--- a/.github/workflows/deploy_tencent_scf.yml
+++ b/.github/workflows/deploy_tencent_scf.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: "将Secrets里面配置的变量添加到severless.yml里面作为环境变量"
         run: |
+          if [ $SCF_REGION ]; then sed -i "s/region:.*$/region: $SCF_REGION/g" serverless.yml; fi;
           if [ $JD_COOKIE ]; then sed -i "/variables/a\      JD_COOKIE: $JD_COOKIE" serverless.yml; fi;
           if [ $JD_DEBUG ]; then sed -i "/variables/a\      JD_DEBUG: $JD_DEBUG" serverless.yml; fi;
           if [ $JD_USER_AGENT ]; then sed -i "/variables/a\      JD_USER_AGENT: $JD_USER_AGENT" serverless.yml; fi;
@@ -85,6 +86,7 @@ jobs:
           cat serverless.yml
           env
         env: #因为直接读取secrets里面的值很多字符不会自动转译，导致写入serverless.yml异常，所以设置到环境变量，在读取环境变量转译过的值
+          SCF_REGION: ${{ secrets.SCF_REGION }}
           JD_COOKIE: ${{ secrets.JD_COOKIE}}
           JD_DEBUG: ${{ secrets.JD_DEBUG}}
           JD_USER_AGENT: ${{ secrets.JD_USER_AGENT}}


### PR DESCRIPTION
SCF_REGION变量可配置列表为：

地域 | 取值
-- | --
华北地区(北京) | ap-beijing
西南地区(成都) | ap-chengdu
西南地区(重庆) | ap-chongqing
华南地区(广州) | ap-guangzhou
港澳台地区(中国香港) | ap-hongkong
亚太南部(孟买) | ap-mumbai
华东地区(上海) | ap-shanghai
华东地区(上海金融) | ap-shanghai-fsi
华南地区(深圳金融) | ap-shenzhen-fsi
亚太东南(新加坡) | ap-singapore
亚太东北(东京) | ap-tokyo
美国西部(硅谷) | na-siliconvalley
北美地区(多伦多) | na-toronto

