### PR TITLE
support random delay for jd_bean_sign.js

### DIFF
--- a/jd_bean_sign.js
+++ b/jd_bean_sign.js
@@ -147,7 +147,7 @@ async function changeFile (content) {
   let newContent = content.replace(/var Key = ''/, `var Key = '${cookie}'`);
   newContent = newContent.replace(/const NodeSet = 'CookieSet.json'/, `const NodeSet = '${NodeSet}'`)
   if (process.env.JD_BEAN_STOP && process.env.JD_BEAN_STOP !== '0') {
-    newContent = newContent.replace(/var stop = 0/, `var stop = ${process.env.JD_BEAN_STOP * 1}`);
+    newContent = newContent.replace(/var stop = '0'/, `var stop = '${process.env.JD_BEAN_STOP}'`);
   }
   const zone = new Date().getTimezoneOffset();
   if (zone === 0) {


### PR DESCRIPTION
new version of JD_DailyBonus.js support new random delay.  Current code is not able to support it correctly which cause file delay replacement would never happend on new JD_DailyBonus.js file.  This pull request fix this issue to support randome delay.